### PR TITLE
added patch, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ Airtable::updateOrCreate(['name' => 'myName'], ['field' => 'myField']);
 Airtable::table('companies')->firstOrCreate(['Company Name' => $team->name]);
 ```
 
+#### Update 
+- First argument will be the id
+- Second argument is the whole record including the updated fields
+
+**Note:** Update is destructive and clear all unspecified cell values if you did not provide a value for them. use PATCH up update specified fields
+
+``` php
+Airtable::table('companies')->update('rec5N7fr8GhDtdNxx', [ 'name' => 'Google', 'country' => 'US']);
+```
+
+#### Patch
+- First argument will be the id
+- Second argument is the field you would like to update
+``` php
+Airtable::table('companies')->patch('rec5N7fr8GhDtdNxx', ['country' => 'US']);
+```
+
 ### Testing
 
 ``` bash

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -26,6 +26,11 @@ class Airtable
         return $this->api->put($id, $data);
     }
 
+    public function patch(string $id, $data)
+    {
+        return $this->api->patch($id, $data);
+    }
+
     public function destroy(string $id)
     {
         return $this->api->delete($id);


### PR DESCRIPTION
The current UPDATE request is destructive. according to Airtable documentation PATCH allows to update specific fields.  I added support for PATCH and updated the README.

Airtable docs:

> To update COMPANIES records, issue a request to the COMPANIES endpoint. A PATCH request will only update the fields you specify, leaving the rest as they were. A PUT request will perform a destructive update and clear all unspecified cell values. The example at the right uses the non-destructive PATCH method.