### PR TITLE
Typecasting conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Define airtables account information in .env:
 AIRTABLE_KEY=
 AIRTABLE_BASE=
 AIRTABLE_TABLE=
+AIRTABLE_TYPECAST=false 
 ```
 
 * `AIRTABLE_KEY` can be retrieved here: https://airtable.com/account
 * `AIRTABLE_BASE` can be found here: https://airtable.com/api, select base then copy from URL: `https://airtable.com/[Base Is Here]/api/docs#curl/introduction`
 * `AIRTABLE_TABLE` can be found in the docs for the appropriate base, this is not case senstive. IE: `tasks`
+* `AIRTABLE_TYPECAST` set this to true to allow automatic casting.
 
 ## Example Config
 

--- a/config/config.php
+++ b/config/config.php
@@ -10,7 +10,7 @@ return [
     | This value can be found in your Airtable account page:
     | https://airtable.com/account
     |
-    */
+     */
     'key' => env('AIRTABLE_KEY'),
 
     /*
@@ -22,7 +22,7 @@ return [
     | https://airtable.com/api
     | https://airtable.com/[BASE_ID]/api/docs#curl/introduction
     |
-    */
+     */
     'base' => env('AIRTABLE_BASE'),
 
     /*
@@ -36,7 +36,7 @@ return [
     | Example:
     | Each record in the `Tasks` contains the following fields
     |
-    */
+     */
     'default' => 'default',
 
     'tables' => [
@@ -49,4 +49,6 @@ return [
 
     'log_http' => env('AIRTABLE_LOG_HTTP', false),
     'log_http_format' => env('AIRTABLE_LOG_HTTP_FORMAT', '{request} >>> {res_body}'),
+
+    'typecast' => env('AIRTABLE_TYPECAST', false),
 ];

--- a/src/AirtableManager.php
+++ b/src/AirtableManager.php
@@ -119,11 +119,7 @@ class AirtableManager
             $httpLogFormat = null;
         }
 
-        if ($this->app['config']['airtable.typecast']) {
-            $airtableTypeCast = $this->app['config']['airtable.typecast'];
-        } else {
-            $airtableTypeCast = false;
-        }
+        $airtableTypeCast = $this->app['config']['airtable.typecast'];
 
         $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat, null, $airtableTypeCast);
 

--- a/src/AirtableManager.php
+++ b/src/AirtableManager.php
@@ -119,7 +119,13 @@ class AirtableManager
             $httpLogFormat = null;
         }
 
-        $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat);
+        if ($this->app['config']['airtable.typecast']) {
+            $airtableTypeCast = $this->app['config']['airtable.typecast'];
+        } else {
+            $airtableTypeCast = false;
+        }
+
+        $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat, $airtableTypeCast);
 
         return new Airtable($client, $table);
     }

--- a/src/AirtableManager.php
+++ b/src/AirtableManager.php
@@ -125,7 +125,7 @@ class AirtableManager
             $airtableTypeCast = false;
         }
 
-        $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat, $airtableTypeCast);
+        $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat, null, $airtableTypeCast);
 
         return new Airtable($client, $table);
     }

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -9,6 +9,7 @@ class AirtableApiClient implements ApiClient
 {
     private $client;
 
+    private $typecast;
     private $base;
     private $table;
 
@@ -16,10 +17,11 @@ class AirtableApiClient implements ApiClient
     private $pageSize = 100;
     private $maxRecords = 100;
 
-    public function __construct($base, $table, $access_token, $httpLogFormat = null, Client $client = null)
+    public function __construct($base, $table, $access_token, $httpLogFormat = null, Client $client = null, $typecast = false)
     {
         $this->base = $base;
         $this->table = $table;
+        $this->typecast = $typecast;
 
         $stack = \GuzzleHttp\HandlerStack::create();
 
@@ -49,7 +51,7 @@ class AirtableApiClient implements ApiClient
 
     public function addFilter($column, $operation, $value)
     {
-        $this->filters [] = "{{$column}}{$operation}\"{$value}\"";
+        $this->filters[] = "{{$column}}{$operation}\"{$value}\"";
 
         return $this;
     }
@@ -107,7 +109,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl();
 
-        $params = ['json' => ['fields' => (object) $contents]];
+        $params = ['json' => ['fields' => (object) $contents, 'typecast' => $this->typecast]];
 
         return $this->decodeResponse($this->client->post($url, $params));
     }
@@ -116,7 +118,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl($id);
 
-        $params = ['json' => ['fields' => (object) $contents]];
+        $params = ['json' => ['fields' => (object) $contents, 'typecast' => $this->typecast]];
 
         return $this->decodeResponse($this->client->put($url, $params));
     }
@@ -125,7 +127,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl($id);
 
-        $params = ['json' => ['fields' => (object) $contents]];
+        $params = ['json' => ['fields' => (object) $contents, 'typecast' => $this->typecast]];
 
         return $this->decodeResponse($this->client->patch($url, $params));
     }
@@ -188,7 +190,7 @@ class AirtableApiClient implements ApiClient
         ], $url);
 
         if ($this->filters) {
-            $url .= '?'.http_build_query([
+            $url .= '?' . http_build_query([
                 'filterByFormula' => implode('&', $this->filters),
             ]);
         }

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -190,7 +190,7 @@ class AirtableApiClient implements ApiClient
         ], $url);
 
         if ($this->filters) {
-            $url .= '?' . http_build_query([
+            $url .= '?'.http_build_query([
                 'filterByFormula' => implode('&', $this->filters),
             ]);
         }


### PR DESCRIPTION
Typecasting conversion is disabled by default, This PR gives an option to enables it by setting `AIRTABLE_TYPECAST=true` in .env

The most use case for this to avoid "INVALID_MULTIPLE_CHOICE_OPTIONS" error  so you can insert new values as multiple choice option.  

Airtable documentation: 
"The Airtable API will perform best-effort automatic data conversion from string values if the typecast parameter is passed in. Automatic conversion is disabled by default to ensure data integrity, but it may be helpful for integrating with 3rd party data sources." 