### PR TITLE
Select specific fields in result

### DIFF
--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -109,6 +109,13 @@ class Airtable
         return $this->create($data);
     }
 
+    public function select(array $fields = [])
+    {
+        $this->api->setFields($fields);
+
+        return $this;
+    }
+
     private function toCollection($object)
     {
         return isset($object['records']) ? collect($object['records']) : $object;

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -36,8 +36,12 @@ class Airtable
         return $this->api->delete($id);
     }
 
-    public function get()
+    public function get(array $fields = [])
     {
+        if($fields) {
+            $this->select($fields);
+        }
+        
         return $this->toCollection($this->api->get());
     }
 

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -41,7 +41,7 @@ class Airtable
         if($fields) {
             $this->select($fields);
         }
-        
+
         return $this->toCollection($this->api->get());
     }
 

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -38,7 +38,7 @@ class Airtable
 
     public function get(array $fields = [])
     {
-        if($fields) {
+        if ($fields) {
             $this->select($fields);
         }
 

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -197,7 +197,7 @@ class AirtableApiClient implements ApiClient
             $this->table,
         ], $url);
 
-        if($query_params = $this->getQueryParams()) {
+        if ($query_params = $this->getQueryParams()) {
             $url .= '?' . http_build_query($query_params);
         }
 

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -198,7 +198,7 @@ class AirtableApiClient implements ApiClient
         ], $url);
 
         if ($query_params = $this->getQueryParams()) {
-            $url .= '?' . http_build_query($query_params);
+            $url .= '?'.http_build_query($query_params);
         }
 
         return $url;

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -197,12 +197,25 @@ class AirtableApiClient implements ApiClient
             $this->table,
         ], $url);
 
-        if ($this->filters) {
-            $url .= '?'.http_build_query([
-                'filterByFormula' => 'AND('.implode(',', $this->filters).')',
-            ]);
+        if($query_params = $this->getQueryParams()) {
+            $url .= '?' . http_build_query($query_params);
         }
 
         return $url;
+    }
+
+    protected function getQueryParams(): array
+    {
+        $query_params = [];
+
+        if ($this->filters) {
+            $query_params['filterByFormula'] = 'AND('.implode(',', $this->filters).')';
+        }
+
+        if ($this->fields) {
+            $query_params['fields'] = $this->fields;
+        }
+
+        return $query_params;
     }
 }

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -14,6 +14,7 @@ class AirtableApiClient implements ApiClient
     private $table;
 
     private $filters = [];
+    private $fields = [];
     private $pageSize = 100;
     private $maxRecords = 100;
 
@@ -168,6 +169,13 @@ class AirtableApiClient implements ApiClient
         }
 
         return json_decode($body, true);
+    }
+
+    public function setFields(?array $fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
     }
 
     protected function getEndpointUrl(?string $id = null): string


### PR DESCRIPTION
This PR adds the possibility to get results only for the selected fields. It also reduces the amount of transfered data.

To select only some specific fields :
```
Airtable::table('products')->get(['code', 'name']);
```

Or can also be set in `select()` params :
```
Airtable::table('products')
   ->select(['code', 'name'])
   ->get();
```

