### PR TITLE
Add mass update feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ Airtable::table('companies')->update('rec5N7fr8GhDtdNxx', [ 'name' => 'Google', 
 Airtable::table('companies')->patch('rec5N7fr8GhDtdNxx', ['country' => 'US']);
 ```
 
+#### Mass Update or Patch
+- Array of data to be updated or patched
+
+``` php
+Airtable::table('companies')->patch([
+    [
+        'id' => 'rec5N7fr8GhDtdNxx',
+        'fields' => ['country' => 'US']
+    ],
+    [
+        'id' => 'rec8BhDt4fs2',
+        'fields' => ['country' => 'UK']
+    ],
+    ...
+]);
+```
+
 ### Testing
 
 ``` bash

--- a/config/config.php
+++ b/config/config.php
@@ -59,13 +59,13 @@ return [
     | Each record in the `Tasks` contains the following fields
     |
      */
-    
+
     'log_http' => env('AIRTABLE_LOG_HTTP', false),
     'log_http_format' => env('AIRTABLE_LOG_HTTP_FORMAT', '{request} >>> {res_body}'),
 
     'typecast' => env('AIRTABLE_TYPECAST', false),
 
-    // The API is limited to 5 requests per second per base. 
+    // The API is limited to 5 requests per second per base.
     // If you exceed this rate, you will receive a 429 status code and will need to wait 30 seconds before a successful request.
     // This value is the delay in microseconds between subsequent requests.
     'delay_between_requests' => env('AIRTABLE_DELAY_BETWEEN_REQUESTS', 200000),

--- a/config/config.php
+++ b/config/config.php
@@ -47,8 +47,26 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Default Airtable Client Settings
+    |--------------------------------------------------------------------------
+    |
+    | This value can be found on the API docs page:
+    | https://airtable.com/[BASE_ID]/api/docs#curl/table:tasks
+    | The value will be hilighted at the beginning of each table section.
+    | Example:
+    | Each record in the `Tasks` contains the following fields
+    |
+     */
+    
     'log_http' => env('AIRTABLE_LOG_HTTP', false),
     'log_http_format' => env('AIRTABLE_LOG_HTTP_FORMAT', '{request} >>> {res_body}'),
 
     'typecast' => env('AIRTABLE_TYPECAST', false),
+
+    // The API is limited to 5 requests per second per base. 
+    // If you exceed this rate, you will receive a 429 status code and will need to wait 30 seconds before a successful request.
+    // This value is the delay in microseconds between subsequent requests.
+    'delay_between_requests' => env('AIRTABLE_DELAY_BETWEEN_REQUESTS', 200000),
 ];

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -2,6 +2,8 @@
 
 namespace Tapp\Airtable;
 
+use InvalidArgumentException;
+
 class Airtable
 {
     private $api;
@@ -21,14 +23,50 @@ class Airtable
         return $this->api->post($data);
     }
 
-    public function update(string $id, $data)
+    /**
+     * @param  dynamic $args (string) $id, $data | (array) $data
+     * @return mixed
+     * 
+     * @throws \InvalidArgumentException
+     */
+    public function update(...$args)
     {
-        return $this->api->put($id, $data);
+        if (is_string($args[0])) {
+            if (! isset($args[1])) {
+                throw new InvalidArgumentException("\$data argument is required.");
+            }
+
+            return $this->api->put($args[0], $args[1]);
+        }
+
+        elseif (is_array($args[0])) {
+            return $this->api->massUpdate('put', $args[0]);
+        }
+
+        throw new InvalidArgumentException('Update accepts either an array or an id and array of data.');
     }
 
-    public function patch(string $id, $data)
+    /**
+     * @param  dynamic $args (string) $id, $data | (array) $data
+     * @return mixed
+     * 
+     * @throws \InvalidArgumentException
+     */
+    public function patch(...$args)
     {
-        return $this->api->patch($id, $data);
+        if (is_string($args[0])) {
+            if (! isset($args[1])) {
+                throw new InvalidArgumentException("\$data argument is required.");
+            }
+
+            return $this->api->patch($args[0], $args[1]);
+        }
+
+        elseif (is_array($args[0])) {
+            return $this->api->massUpdate('patch', $args[0]);
+        }
+
+        throw new InvalidArgumentException('Patch accepts either an array or an id and array of data.');
     }
 
     public function destroy(string $id)

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -26,20 +26,18 @@ class Airtable
     /**
      * @param  dynamic $args (string) $id, $data | (array) $data
      * @return mixed
-     * 
+     *
      * @throws \InvalidArgumentException
      */
     public function update(...$args)
     {
         if (is_string($args[0])) {
             if (! isset($args[1])) {
-                throw new InvalidArgumentException("\$data argument is required.");
+                throw new InvalidArgumentException('$data argument is required.');
             }
 
             return $this->api->put($args[0], $args[1]);
-        }
-
-        elseif (is_array($args[0])) {
+        } elseif (is_array($args[0])) {
             return $this->api->massUpdate('put', $args[0]);
         }
 
@@ -49,20 +47,18 @@ class Airtable
     /**
      * @param  dynamic $args (string) $id, $data | (array) $data
      * @return mixed
-     * 
+     *
      * @throws \InvalidArgumentException
      */
     public function patch(...$args)
     {
         if (is_string($args[0])) {
             if (! isset($args[1])) {
-                throw new InvalidArgumentException("\$data argument is required.");
+                throw new InvalidArgumentException('$data argument is required.');
             }
 
             return $this->api->patch($args[0], $args[1]);
-        }
-
-        elseif (is_array($args[0])) {
+        } elseif (is_array($args[0])) {
             return $this->api->massUpdate('patch', $args[0]);
         }
 

--- a/src/AirtableManager.php
+++ b/src/AirtableManager.php
@@ -120,8 +120,9 @@ class AirtableManager
         }
 
         $airtableTypeCast = $this->app['config']['airtable.typecast'];
+        $delay = $this->app['config']['airtable.delay_between_requests'];
 
-        $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat, null, $airtableTypeCast);
+        $client = new AirtableApiClient($base, $table, $access_token, $httpLogFormat, null, $airtableTypeCast, $delay);
 
         return new Airtable($client, $table);
     }

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -121,6 +121,21 @@ class AirtableApiClient implements ApiClient
         return $this->decodeResponse($this->client->patch($url, $params));
     }
 
+    public function massUpdate(string $method, array $data)
+    {
+        $url = $this->getEndpointUrl();
+        $records = [];
+
+        foreach (array_chunk($data, 10) as $data_chunk) {
+            $params = ['json' => ['records' => $data, 'typecast' => $this->typecast]];
+
+            $response = $this->decodeResponse($this->client->$method($url, $params));
+            $records += $response['records'];
+        }
+
+        return ['records' => $records];
+    }
+
     public function delete(string $id)
     {
         $url = $this->getEndpointUrl($id);

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -136,7 +136,7 @@ class AirtableApiClient implements ApiClient
             $response = $this->decodeResponse($this->client->$method($url, $params));
             $records += $response['records'];
 
-            if (isset($chunks[$key+1])) {
+            if (isset($chunks[$key + 1])) {
                 usleep($this->delay);
             }
         }

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -12,6 +12,7 @@ class AirtableApiClient implements ApiClient
     private $typecast;
     private $base;
     private $table;
+    private $delay;
 
     private $filters = [];
     private $fields = [];
@@ -19,11 +20,12 @@ class AirtableApiClient implements ApiClient
     private $pageSize = 100;
     private $maxRecords = 100;
 
-    public function __construct($base, $table, $access_token, $httpLogFormat = null, Client $client = null, $typecast = false)
+    public function __construct($base, $table, $access_token, $httpLogFormat = null, Client $client = null, $typecast = false, $delayBetweenRequests = 200000)
     {
         $this->base = $base;
         $this->table = $table;
         $this->typecast = $typecast;
+        $this->delay = $delayBetweenRequests;
 
         $stack = \GuzzleHttp\HandlerStack::create();
 
@@ -126,11 +128,17 @@ class AirtableApiClient implements ApiClient
         $url = $this->getEndpointUrl();
         $records = [];
 
-        foreach (array_chunk($data, 10) as $data_chunk) {
-            $params = ['json' => ['records' => $data, 'typecast' => $this->typecast]];
+        // Update & Patch request body can include an array of up to 10 record objects
+        $chunks = array_chunk($data, 10);
+        foreach ($chunks as $key => $data_chunk) {
+            $params = ['json' => ['records' => $data_chunk, 'typecast' => $this->typecast]];
 
             $response = $this->decodeResponse($this->client->$method($url, $params));
             $records += $response['records'];
+
+            if (isset($chunks[$key+1])) {
+                usleep($this->delay);
+            }
         }
 
         return ['records' => $records];


### PR DESCRIPTION
This PR adds the ability to do a mass update or patch to your Airtable data.

Both patch() and update() arguments are dynamic. 

- In order to update a single is unchanged and still
``` php
Airtable::table('companies')->update('rec5N7fr8GhDtdNxx', ['country' => 'US']);
```

- In order to update multiple records only an array of data is required
``` php
Airtable::table('companies')->patch([
    [
        'id' => 'rec5N7fr8GhDtdNxx',
        'fields' => ['country' => 'US']
    ],
    [
        'id' => 'rec8BhDt4fs2',
        'fields' => ['country' => 'UK']
    ],
    ...
]);
```

