### PR TITLE
Add sorting support, fixes #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ Airtable::where('id', '5')->get();
 Airtable::where('id', '>', '5')->get();
 ```
 
+#### Sorting records
+
+- First argument is the column name
+- Second argument is the sort direction: `asc` (default) or `desc`
+
+``` php
+Airtable::orderBy('id')->get();
+Airtable::orderBy('created_at', 'desc')->get();
+```
+You can sort by multiple fields by calling `orderBy` more than once (a single call with array syntax is not supported):
+```php
+Airtable::orderBy('id')->orderBy('created_at', 'desc')->get();
+```
+
 #### First or Create
 - First argument will be used for finding existing
 - Second argument is additional data to save if no results are found and we are creating (will not be saved used if item already exists)

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -106,6 +106,13 @@ class Airtable
         return $this;
     }
 
+    public function orderBy(string $column, string $direction = 'asc')
+    {
+        $this->api->addSort($column, $direction);
+
+        return $this;
+    }
+
     public function firstOrCreate(array $idData, array $createData = [])
     {
         foreach ($idData as $key => $value) {

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -16,6 +16,7 @@ class AirtableApiClient implements ApiClient
 
     private $filters = [];
     private $fields = [];
+    private $sorts = [];
     private $offset = false;
     private $pageSize = 100;
     private $maxRecords = 100;
@@ -56,6 +57,17 @@ class AirtableApiClient implements ApiClient
     public function addFilter($column, $operation, $value)
     {
         $this->filters[] = "{{$column}}{$operation}\"{$value}\"";
+
+        return $this;
+    }
+
+    public function addSort(string $column, string $direction = 'asc')
+    {
+        if ($direction === 'desc') {
+            $this->sorts[] = ['field' => $column, 'direction' => $direction];
+        } else {
+            $this->sorts[] = ['field' => $column];
+        }
 
         return $this;
     }
@@ -229,6 +241,10 @@ class AirtableApiClient implements ApiClient
 
         if ($this->offset) {
             $query_params['offset'] = $this->offset;
+        }
+
+        if ($this->sorts) {
+            $query_params['sort'] = $this->sorts;
         }
 
         return $query_params;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -20,8 +20,8 @@ class ClientTest extends TestCase
     public function it_can_post()
     {
         $expectedResponse = [
-            'id' => 'randomlygenerated',
-            'fields' => ['Company Name' => 'Tapp Network'],
+            'id'          => 'randomlygenerated',
+            'fields'      => ['Company Name' => 'Tapp Network'],
             'createdTime' => 'timestamp',
         ];
 
@@ -32,7 +32,7 @@ class ClientTest extends TestCase
             '/v0/test_base/companies',
             [
                 'json' => [
-                    'fields' => (object) $postData,
+                    'fields' => (object)$postData,
                 ],
             ]
         );
@@ -73,6 +73,78 @@ class ClientTest extends TestCase
         $first = $actualResponse['records'][0];
 
         $this->assertEquals($expectedResponse['fields'], $first['fields']);
+    }
+
+    /** @test */
+    public function it_can_sort()
+    {
+        //Ascending sort
+        $expectedResponseAsc = [
+            [
+                'id'          => 0,
+                'fields'      => ['Company Name' => 'A Network'],
+                'createdTime' => 'timestamp',
+            ],
+            [
+                'id'          => 1,
+                'fields'      => ['Company Name' => 'B Network'],
+                'createdTime' => 'timestamp',
+            ],
+        ];
+
+        $mockGuzzle = $this->mock_guzzle_request(
+            json_encode($expectedResponseAsc),
+            '/v0/test_base/companies',
+            [
+                'json' => [
+                    'sort' => '[{field:"Company Name",direction:"asc"}]',
+                ],
+            ]
+        );
+
+        $client = $this->build_client($mockGuzzle);
+
+        $actualResponse = $client->setTable('companies')
+            ->addSort('Company Name', 'asc')
+            ->get();
+
+        $first = $actualResponse['records'][0];
+
+        $this->assertEquals($expectedResponseAsc['fields'], $first['fields']);
+
+        //Descending sort
+        $expectedResponseDesc = [
+            [
+                'id'          => 1,
+                'fields'      => ['Company Name' => 'B Network'],
+                'createdTime' => 'timestamp',
+            ],
+            [
+                'id'          => 0,
+                'fields'      => ['Company Name' => 'A Network'],
+                'createdTime' => 'timestamp',
+            ],
+        ];
+
+        $mockGuzzle = $this->mock_guzzle_request(
+            json_encode($expectedResponseDesc),
+            '/v0/test_base/companies',
+            [
+                'json' => [
+                    'sort' => '[{field:"Company Name",direction:"desc"}]',
+                ],
+            ]
+        );
+
+        $client = $this->build_client($mockGuzzle);
+
+        $actualResponse = $client->setTable('companies')
+            ->addSort('Company Name', 'desc')
+            ->get();
+
+        $first = $actualResponse['records'][0];
+
+        $this->assertEquals($expectedResponseDesc['fields'], $first['fields']);
     }
 
     private function build_client($mockGuzzle = null)


### PR DESCRIPTION
I have added sorting support, with docs, and it seems to work nicely.

Unfortunately I can't make your test suite work at all. It seems quite broken on Travis CI, and it won't run at all on PHP 8 (see #42). I wrote some tests anyway, but I don't understand how the guzzle mock works so they are probably wrong.