### PR TITLE
update readme with instructions for PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AIRTABLE_TABLE=
 AIRTABLE_TYPECAST=false 
 ```
 
-* `AIRTABLE_KEY` can be retrieved here: https://airtable.com/account
+* `AIRTABLE_KEY` Airtable is requiring personal access tokens for Authorization starting in 2024. A token can be created here: https://airtable.com/create/tokens. If you are upgrading from an API key to access token, simply replace the value previously held in this environment variable with your new token.
 * `AIRTABLE_BASE` can be found here: https://airtable.com/api, select base then copy from URL: `https://airtable.com/[Base Is Here]/api/docs#curl/introduction`
 * `AIRTABLE_TABLE` can be found in the docs for the appropriate base, this is not case senstive. IE: `tasks`
 * `AIRTABLE_TYPECAST` set this to true to allow automatic casting.


### PR DESCRIPTION
# Description
Airtable is migrating away from API keys in favor or Personal Access Tokens. While the Airtable API currently allows you to use both interchangeably, this PR updates the readme, so that users will know they can place their access token in the same environment variable the is currently used to house their API key without any other changes.

# Steps to test
1. Create a PAT at airtable.com/create/tokens. Make sure you token have appropriate access to the tables used by your app.
2. Go to a project using this package
3. Place the PAT in your AIRTABLE_KEY .env variable
4. run 'composer cache:clear' to ensure new variable is being read from .env
5. open tinker and print the response from Airtable::table('your_table_name')->get();
6. The contents of the table should be returned.
7. Alternatively, place a dd statement after somewhere Airtable::table() is called in your codebase and ensure data is still being returned when you switch from key to PAT.