### PR TITLE
Add `deleteMultiple` method to delete multiple records at once

### DIFF
--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -187,6 +187,11 @@ class Airtable
         return $this->api->upsert($data, $fieldsToMergeOn);
     }
 
+    public function deleteMultiple(array $recordIds)
+    {
+        return $this->api->deleteMultiple($recordIds);
+    }
+
     private function toCollection($object)
     {
         return isset($object['records']) ? collect($object['records']) : $object;

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -312,4 +312,39 @@ class AirtableApiClient implements ApiClient
 
         return $query_params;
     }
+
+    public function deleteMultiple(array $ids)
+    {
+        $records = [];
+        $chunks = array_chunk($ids, 10);
+        foreach ($chunks as $chunk) {
+            $url = $this->getEndpointUrl();
+            $first = true;
+            foreach ($chunk as $id) {
+                if ($first) {
+                    $url .= '?records=' . $id;
+                } else {
+                    $url .= '&records=' . $id;
+                }
+
+                $first = false;
+            }
+
+            $responseData = $this->decodeResponse(
+                $this->client->delete($url)
+            );
+
+            if ($responseData->has('error')) {
+                return $responseData;
+            }
+
+            if ($responseData->has('records')) {
+                $records += $responseData->get('records');
+            }
+        }
+
+        return collect([
+            'records' => $records,
+        ]);
+    }
 }


### PR DESCRIPTION
Added possibility to delete more than one record at once using a new `deleteMultiple` method. I considered to refactor and change the `delete` method, but the return value is in different format, so finally I decided to add a new method.